### PR TITLE
Fixed for unreal 4.18 build

### DIFF
--- a/Source/SpoutPlugin/Public/SpoutBPFunctionLibrary.h
+++ b/Source/SpoutPlugin/Public/SpoutBPFunctionLibrary.h
@@ -34,7 +34,7 @@ enum class ESpoutSendTextureFrom : uint8
 	TextureRenderTarget2D
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FSenderStruct
 {
 	GENERATED_USTRUCT_BODY()


### PR DESCRIPTION
Unreal 4.18 doesn't like the ustruct without the blueprint type in it.