### PR TITLE
Export USpoutBPFunctionLibrary for linking

### DIFF
--- a/Source/SpoutPlugin/Public/SpoutBPFunctionLibrary.h
+++ b/Source/SpoutPlugin/Public/SpoutBPFunctionLibrary.h
@@ -108,7 +108,7 @@ struct FSenderStruct
 
 
 UCLASS(ClassGroup = Spout, Blueprintable)
-class USpoutBPFunctionLibrary : public UBlueprintFunctionLibrary
+class SPOUTPLUGIN_API USpoutBPFunctionLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
Hi, I'm working on a different plug-in which manages a render target that I want to send to Spout. To prevent my users to have to do any kind of setup, in e.g. Level BP Tick to fetch my plug-in's render target and send it to Spout via the `SpoutSender` function, I decided to have my code tie directly in to your code (Plug-in dependencies are supported since 4.17).

This causes link errors since your static BP function lib isn't being exported, so I simply added that macro to the header file. Allowing me to call `USpoutBPFunctionLibrary::SpoutSender(...)` etc from my code.

Please consider merging this minor fix, so I don't have to send around a custom built version of SpoutPlugin with my plug-in.

Thanks a bunch for the plug-in to begin with! :clap: 

Cheers,
Tobias.

:tada: 