### PR TITLE
Updated to 4.23, fixed bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,51 @@
+*Modification of original plugin by [AleDel](https://github.com/AleDel/Spout-UE4) with UE versions 4.19+.*
+
+**This was tested with:**
+* 4.19
+* 4.20
+* 4.21
+* 4.22
+* 4.23
+
 # Spout-UE4
-[Spout](http://spout.zeal.co/) Plugin for Unreal Engine
+This is a [Spout](http://spout.zeal.co/) Plugin for Unreal Engine. It allows you to send and receive textures using Spout framework.
 
 Sender and Receiver only DirectX 11.
 
 # Installation and Use
 
-Put code in folder Plugins (for example "yourproject/Plugins/SpoutUE4")
+Put the code in _Plugins_ folder (for example "_yourproject/Plugins/Spout-UE4_"). For detailed instructions please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR). This video is a good step-by-step walkthrough of how to set up your project for use with the plugin.
 
-# Info
+## Sending Spout
 
-the "spout sender" has two options: 
-  * "Game Viewport" that send the image of the viewport (no work in standalone game) 
-  * or use a "TextureRenderTarget2D" in this case you should create along with a "SceneCaptureComponent2D"
+This is done with the **Spout sender** node which has can send texture either from the Game viewport or from a Render Targert 2D: 
+  * **Game Viewport** sends the image of the viewport, but please note that it doesn't work in standalone or packaged game.
+  * **TextureRenderTarget2D** in which case you should create a _SceneCaptureComponent2D_ and a *Render target 2D* which you should reference in the node.
 
-use "spout close" blueprint to close spouts
+use **Close Sender** node to close Spouts. The best way is to connect it to **Event EndPlay** node.
 
-![CaptureSpout2](http://aledel.github.io/Spout-UE4/images/10senders.jpg)
-test sending 10 sender to Touchdesigner 1024x768 either one, the performance is good.
+## Install Example
 
-# Install Example
-
-* Create new c++ First Person project
-* unzip example in the "Content" folder of your project
+* Create new C++ *First Person* project
+* unzip ExampleSpout.zip in the "Content" folder of your project
 * unzip code plugin in folder "Plugins" as mentioned above, if there is no "Plugins" folder, create it
 * restart project
 * load Spout scene
+* if you encounter compile errors you have to delete and re-insert identical nodes
 
 [ExampleSpout.zip](http://aledel.github.io/Spout-UE4/exampleSpoutUE4/ExampleSpout.zip)
 
 ![CaptureSpout2](http://aledel.github.io/Spout-UE4/images/spout2.jpg)
 This image corresponds to the "Spout" scene. 
 
+## Packaged game
+To make this plugin work in a packaged game you have to disable using 'pak' files. You do that by:
+1. going to File->Package project->Packaging settings
+2. once there uncheck 'Use Pak File' checkbox
+
+# Issues
+If you get missing Spout.dll error when trying to launch the game manually copy Spout.dll from:
+`[gameName]\Plugins\SpoutUE4\ThirdParty\Spout\lib\amd64`
+
+to: 
+`[gameName]\Binaries\Win64`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Sender and Receiver only DirectX 11.
 
 9. In the project directory, open the .uproject file. Press Yes when asked if you'd like to rebuild the SpoutPlugin module.
 ![Image 7](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
-
 It will start to build.
 ![Image 8](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It will start to build.
 12. *(Optional)* Open the ExampleSpout > Spout project and press Play. Configure the Sender and Receiver names to work with other software.
 ![Step 11](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
 
-For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR). This video provides a good step-by-step walkthrough of how to set up your project for use with the plugin.
+For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR), which provides a good step-by-step walkthrough of how to set up your project for use with the plugin.
 
 ## Sending Spout
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,3 @@ To make this plugin work in a packaged game you have to disable using 'pak' file
 1. going to File->Package project->Packaging settings
 2. once there uncheck 'Use Pak File' checkbox
 
-# Issues
-If you get missing Spout.dll error when trying to launch the game manually copy Spout.dll from:
-`[gameName]\Plugins\SpoutUE4\ThirdParty\Spout\lib\amd64`
-
-to: 
-`[gameName]\Binaries\Win64`

--- a/README.md
+++ b/README.md
@@ -17,41 +17,41 @@ Sender and Receiver only DirectX 11.
 1. Open up Epic Games Launcher (make sure it's up to date).
 
 2. Create a new C++ First person Project.
-![Step 1](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_01.png)
+![Image 1](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_01.png)
 
 3. You should see it Generating code...
-![Step 2](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_02.png)
+![Image 2](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_02.png)
 
 4. The Unreal project will open in the editor, and a Visual Studio project will also open.
-![Step 3](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_03.png)
+![Image 3](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_03.png)
 
 5. Close the Unreal project.
 
 6. In the project directory, create a Plugins folder.
-![Step 4](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_04.png)
+![Image 4](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_04.png)
 
 7. Download the Spout-UE4 repository (zip file) and put it in the Plugins directory.
-![Step 5](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_05.png)
+![Image 5](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_05.png)
 
 8. *(Optional)* Download ExampleSpout.zip (from the project GitHub page). Unzip the contents into the Content folder.
-![Step 6](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_06.png)
+![Image 6](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_06.png)
 
 9. In the project directory, open the .uproject file. Press Yes when asked if you'd like to rebuild the SpoutPlugin module.
-![Step 7](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
+![Image 7](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
 
 It will start to build.
-![Step 8](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
+![Image 8](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
 
 10. Once the project opens, go to Settings > Plugins.
-![Step 9](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_09.png)
+![Image 9](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_09.png)
 
 11. Make sure the Spout Plugin is enabled. If necessary, restart.
-![Step 10](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_10.png)
+![Image 10](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_10.png)
 
 12. *(Optional)* Open the ExampleSpout > Spout project and press Play. Configure the Sender and Receiver names to work with other software.
-![Step 11](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
+![Image 11](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
 
-For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR), which provides a good step-by-step walkthrough of how to set up your project for use with the plugin.
+For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR), which provides a good step-by-Image walkthrough of how to set up your project for use with the plugin.
 
 ## Sending Spout
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ To make this plugin work in a packaged game you have to disable using 'pak' file
 1. going to File->Package project->Packaging settings
 2. once there uncheck 'Use Pak File' checkbox
 
+This is only necessary if you are using the *Mat* pin on the *Spout Receiver* node.

--- a/README.md
+++ b/README.md
@@ -17,38 +17,38 @@ Sender and Receiver only DirectX 11.
 1. Open up Epic Games Launcher (make sure it's up to date).
 
 2. Create a new C++ First person Project.
-![Image 1](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_01.png)
+![Image 1](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_01.png)
 
 3. You should see it Generating code...
-![Image 2](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_02.png)
+![Image 2](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_02.png)
 
 4. The Unreal project will open in the editor, and a Visual Studio project will also open.
-![Image 3](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_03.png)
+![Image 3](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_03.png)
 
 5. Close the Unreal project.
 
 6. In the project directory, create a Plugins folder.
-![Image 4](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_04.png)
+![Image 4](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_04.png)
 
 7. Download the Spout-UE4 repository (zip file) and put it in the Plugins directory.
-![Image 5](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_05.png)
+![Image 5](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_05.png)
 
 8. *(Optional)* Download ExampleSpout.zip (from the project GitHub page). Unzip the contents into the Content folder.
-![Image 6](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_06.png)
+![Image 6](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_06.png)
 
 9. In the project directory, open the .uproject file. Press Yes when asked if you'd like to rebuild the SpoutPlugin module.
-![Image 7](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
+![Image 7](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
 It will start to build.
-![Image 8](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
+![Image 8](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
 
 10. Once the project opens, go to Settings > Plugins.
-![Image 9](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_09.png)
+![Image 9](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_09.png)
 
 11. Make sure the Spout Plugin is enabled. If necessary, restart.
-![Image 10](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_10.png)
+![Image 10](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_10.png)
 
 12. *(Optional)* Open the ExampleSpout > Spout project and press Play. Configure the Sender and Receiver names to work with other software.
-![Image 11](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
+![Image 11](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
 
 For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR), which provides a good step-by-Image walkthrough of how to set up your project for use with the plugin.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,44 @@ Sender and Receiver only DirectX 11.
 
 # Installation and Use
 
-Put the code in _Plugins_ folder (for example "_yourproject/Plugins/Spout-UE4_"). For detailed instructions please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR). This video is a good step-by-step walkthrough of how to set up your project for use with the plugin.
+1. Open up Epic Games Launcher (make sure it's up to date).
+
+2. Create a new C++ First person Project.
+![Step 1](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_01.png)
+
+3. You should see it Generating code...
+![Step 2](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_02.png)
+
+4. The Unreal project will open in the editor, and a Visual Studio project will also open.
+![Step 3](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_03.png)
+
+5. Close the Unreal project.
+
+6. In the project directory, create a Plugins folder.
+![Step 4](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_04.png)
+
+7. Download the Spout-UE4 repository (zip file) and put it in the Plugins directory.
+![Step 5](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_05.png)
+
+8. *(Optional)* Download ExampleSpout.zip (from the project GitHub page). Unzip the contents into the Content folder.
+![Step 6](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_06.png)
+
+9. In the project directory, open the .uproject file. Press Yes when asked if you'd like to rebuild the SpoutPlugin module.
+![Step 7](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
+
+It will start to build.
+![Step 8](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
+
+10. Once the project opens, go to Settings > Plugins.
+![Step 9](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_09.png)
+
+11. Make sure the Spout Plugin is enabled. If necessary, restart.
+![Step 10](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_10.png)
+
+12. *(Optional)* Open the ExampleSpout > Spout project and press Play. Configure the Sender and Receiver names to work with other software.
+![Step 11](http://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
+
+For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR). This video provides a good step-by-step walkthrough of how to set up your project for use with the plugin.
 
 ## Sending Spout
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 *Modification of original plugin by [AleDel](https://github.com/AleDel/Spout-UE4) with UE versions 4.19+.*
 
+# Spout-UE4
+This is a [Spout](http://spout.zeal.co/) Plugin for Unreal Engine. It allows you to send and receive textures using Spout framework.
+
+Sender and Receiver only DirectX 11.
+
+* [Installation and Use](#installation-and-use)
+* [Sending Spout](#sending-spout)
+* [Install Example](#install-example)
+* [Packaged game](#packaged-game)
+
 **This was tested with:**
 * 4.19
 * 4.20
@@ -7,47 +17,55 @@
 * 4.22
 * 4.23
 
-# Spout-UE4
-This is a [Spout](http://spout.zeal.co/) Plugin for Unreal Engine. It allows you to send and receive textures using Spout framework.
-
-Sender and Receiver only DirectX 11.
 
 # Installation and Use
 
 1. Open up Epic Games Launcher (make sure it's up to date).
 
 2. Create a new C++ First person Project.
+
 ![Image 1](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_01.png)
 
 3. You should see it Generating code...
+
 ![Image 2](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_02.png)
 
 4. The Unreal project will open in the editor, and a Visual Studio project will also open.
+
 ![Image 3](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_03.png)
 
 5. Close the Unreal project.
 
 6. In the project directory, create a Plugins folder.
+
 ![Image 4](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_04.png)
 
 7. Download the Spout-UE4 repository (zip file) and put it in the Plugins directory.
+
 ![Image 5](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_05.png)
 
 8. *(Optional)* Download ExampleSpout.zip (from the project GitHub page). Unzip the contents into the Content folder.
+
 ![Image 6](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_06.png)
 
 9. In the project directory, open the .uproject file. Press Yes when asked if you'd like to rebuild the SpoutPlugin module.
+
 ![Image 7](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_07.png)
+
 It will start to build.
+
 ![Image 8](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_08.png)
 
 10. Once the project opens, go to Settings > Plugins.
+
 ![Image 9](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_09.png)
 
 11. Make sure the Spout Plugin is enabled. If necessary, restart.
+
 ![Image 10](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_10.png)
 
 12. *(Optional)* Open the ExampleSpout > Spout project and press Play. Configure the Sender and Receiver names to work with other software.
+
 ![Image 11](https://L05.github.io/Spout-UE4/images/SpoutExample_Instructions_11.png)
 
 For video instructions, please refer to [Unreal Engine 4 and Lightact Video Tutorials](https://www.youtube.com/playlist?list=PLcNPGta1d2XDcSsz8zcW0f2lPSawnW3mR), which provides a good step-by-Image walkthrough of how to set up your project for use with the plugin.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use **Close Sender** node to close Spouts. The best way is to connect it to **Ev
 * load Spout scene
 * if you encounter compile errors you have to delete and re-insert identical nodes
 
-[ExampleSpout.zip](http://aledel.github.io/Spout-UE4/exampleSpoutUE4/ExampleSpout.zip)
+[ExampleSpout.zip](http://L05.github.io/Spout-UE4/exampleSpoutUE4/ExampleSpout.zip) *(Updated on 9/22/2019)*
 
 ![CaptureSpout2](http://aledel.github.io/Spout-UE4/images/spout2.jpg)
 This image corresponds to the "Spout" scene. 

--- a/Source/SpoutPlugin/Private/SpoutBPFunctionLibrary.cpp
+++ b/Source/SpoutPlugin/Private/SpoutBPFunctionLibrary.cpp
@@ -478,6 +478,7 @@ bool USpoutBPFunctionLibrary::SpoutSender(FName spoutName, ESpoutSendTextureFrom
 		return false;
 	}
 	
+	// TODO needs to be updated to ENQUEUE_UNIQUE_RENDER for 4.22
 	//Sincroniza el thread del render y la copia de la textura
 	ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
 		void,

--- a/Source/SpoutPlugin/Private/SpoutBPFunctionLibrary.cpp
+++ b/Source/SpoutPlugin/Private/SpoutBPFunctionLibrary.cpp
@@ -200,7 +200,7 @@ FSenderStruct* RegisterReceiver(FName spoutName){
 	newFSenderStruc->texTemp = NULL;
 
 	//TextureColor = new
-	UE_LOG(SpoutLog, Warning, TEXT("No material intance, creating...//////"));
+	UE_LOG(SpoutLog, Warning, TEXT("No material instance, creating...//////"));
 	// Prepara Textura, Set the texture update region
 	newFSenderStruc->UpdateRegions = new FUpdateTextureRegion2D(0, 0, 0, 0, newFSenderStruc->w, newFSenderStruc->h);
 	ResetTexture(newFSenderStruc->TextureColor, newFSenderStruc->MaterialInstanceColor, newFSenderStruc);
@@ -239,7 +239,7 @@ FSenderStruct* RegisterReceiver(FName spoutName){
 	description.ArraySize = 1;
 
 
-	UE_LOG(SpoutLog, Warning, TEXT("--- Creando d3d11 Texture 2D---"));
+	UE_LOG(SpoutLog, Warning, TEXT("--- Creating d3d11 Texture 2D---"));
 
 	HRESULT hr = g_D3D11Device->CreateTexture2D(&description, NULL, &newFSenderStruc->texTemp);
 
@@ -249,7 +249,7 @@ FSenderStruct* RegisterReceiver(FName spoutName){
 		ss << " Error code = 0x" << std::hex << hr << std::endl;
 		std::cout << ss.str() << std::endl;
 		std::string TestString = ss.str();
-		UE_LOG(SpoutLog, Error, TEXT("Failed Create Texture: ----> %s"), *FString(TestString.c_str()));
+		UE_LOG(SpoutLog, Error, TEXT("Failed to create texture of name: ----> %s"), *FString(TestString.c_str()));
 
 		if (hr == E_OUTOFMEMORY) {
 			UE_LOG(SpoutLog, Error, TEXT("OUT OF MEMORY"));
@@ -259,7 +259,7 @@ FSenderStruct* RegisterReceiver(FName spoutName){
 			newFSenderStruc->texTemp->Release();
 			newFSenderStruc->texTemp = NULL;
 		}
-		UE_LOG(SpoutLog, Error, TEXT("error creating temporal textura"));
+		UE_LOG(SpoutLog, Error, TEXT("Error creating temporal textura"));
 		return false;
 
 	}
@@ -282,7 +282,7 @@ bool USpoutBPFunctionLibrary::SpoutInfoFrom(FName spoutName, FSenderStruct& Send
 	FSenderStruct* EncontradoSenderStruct = FSenders.FindByPredicate(MyPredicate);
 
 	if (EncontradoSenderStruct == nullptr){
-		UE_LOG(SpoutLog, Warning, TEXT("No Encontrado sender con nombre : %s"), *spoutName.GetPlainNameString());
+		UE_LOG(SpoutLog, Warning, TEXT("No Sender was found with the name : %s"), *spoutName.GetPlainNameString());
 		return false;
 	}
 	else
@@ -311,7 +311,7 @@ bool USpoutBPFunctionLibrary::CreateRegisterSender(FName spoutName, ID3D11Textur
 	baseTexture->GetDesc(&desc);
 	ID3D11Texture2D * sendingTexture;
 
-	UE_LOG(SpoutLog, Warning, TEXT("ID3D11Texture2D Info : ancho_%i, alto_%i"), desc.Width, desc.Height);
+	UE_LOG(SpoutLog, Warning, TEXT("ID3D11Texture2D Info : width_%i, height_%i"), desc.Width, desc.Height);
 	UE_LOG(SpoutLog, Warning, TEXT("ID3D11Texture2D Info : Format is %i"), int(desc.Format));
 
 	//use the pixel format from basetexture (the native texture textureRenderTarget2D)
@@ -434,12 +434,12 @@ bool USpoutBPFunctionLibrary::SpoutSender(FName spoutName, ESpoutSendTextureFrom
 	ESpoutState state = CheckSenderState(spoutName);
 
 	if (state == ESpoutState::noEnoR || state == ESpoutState::noER) {
-		UE_LOG(SpoutLog, Warning, TEXT("New Sender creating, registering..."));
+		UE_LOG(SpoutLog, Warning, TEXT("Creating and registering new Sender..."));
 		CreateRegisterSender(spoutName, baseTexture);
 		return false;
 	}
 	if (state == ESpoutState::EnoR) {
-		UE_LOG(SpoutLog, Warning, TEXT("Already exist a Sender with the name %s"), *spoutName.GetPlainNameString());
+		UE_LOG(SpoutLog, Warning, TEXT("A Sender with the name %s already exists"), *spoutName.GetPlainNameString());
 		return false;
 	}
 	if (state == ESpoutState::ER) {
@@ -455,7 +455,7 @@ bool USpoutBPFunctionLibrary::SpoutSender(FName spoutName, ESpoutSendTextureFrom
 			}
 		}
 		if (SenderStruct->spoutType == ESpoutType::Receiver) {
-			UE_LOG(SpoutLog, Warning, TEXT("Already exist a Sender with the name %s and you have a receiver in unreal receiving"), *spoutName.GetPlainNameString());
+			UE_LOG(SpoutLog, Warning, TEXT("A Sender with the name %s already exists, and you have a receiver in Unreal that is receiving"), *spoutName.GetPlainNameString());
 			
 			return false;
 		}	
@@ -478,17 +478,10 @@ bool USpoutBPFunctionLibrary::SpoutSender(FName spoutName, ESpoutSendTextureFrom
 		return false;
 	}
 	
-	// TODO needs to be updated to ENQUEUE_UNIQUE_RENDER for 4.22
-	//Sincroniza el thread del render y la copia de la textura
-	ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
-		void,
-		ID3D11Texture2D*, tt, targetTex,
-		ID3D11Texture2D*, bt, baseTexture,
-		{
-			
-			g_pImmediateContext->CopyResource(tt, bt);
-			g_pImmediateContext->Flush(); 	
-			
+	ENQUEUE_RENDER_COMMAND(void)(
+		[targetTex, baseTexture](FRHICommandListImmediate& RHICmdList) {
+			g_pImmediateContext->CopyResource(targetTex, baseTexture);
+			g_pImmediateContext->Flush();
 		});
 	
 	D3D11_TEXTURE2D_DESC td;
@@ -523,20 +516,20 @@ bool USpoutBPFunctionLibrary::SpoutReceiver(const FName spoutName, UMaterialInst
 	ESpoutState state = CheckSenderState(spoutName);
 
 	if (state == ESpoutState::noEnoR) {
-		UE_LOG(SpoutLog, Warning, TEXT("Not found any sender and no registred with the name %s"), *spoutName.GetPlainNameString());
-		UE_LOG(SpoutLog, Warning, TEXT("try to rename it, or resend %s"), *SenderNameString);
+		UE_LOG(SpoutLog, Warning, TEXT("No sender found registered with the name %s"), *spoutName.GetPlainNameString());
+		UE_LOG(SpoutLog, Warning, TEXT("Try to rename it, or resend %s"), *SenderNameString);
 		return false;
 	}
 		
 	if(state == ESpoutState::noER) {
-		UE_LOG(SpoutLog, Warning, TEXT("why are you registred??, unregistre, best close it"));
+		UE_LOG(SpoutLog, Warning, TEXT("Why are you registered??, unregister, best to close it"));
 		//UnregisterSpout(spoutName);
 		CloseSender(spoutName);
 		return false;
 	}
 
 	if (state == ESpoutState::EnoR) {
-		UE_LOG(SpoutLog, Warning, TEXT("Sender %s found, registring, receiving..."), *spoutName.GetPlainNameString());
+		UE_LOG(SpoutLog, Warning, TEXT("Sender %s found, registering, receiving..."), *spoutName.GetPlainNameString());
 		RegisterReceiver(spoutName);
 		return false;
 	}
@@ -554,14 +547,15 @@ bool USpoutBPFunctionLibrary::SpoutReceiver(const FName spoutName, UMaterialInst
 
 			//communication between the two threads (rendering thread and game thread)
 			// copy pixels from shared resource texture to texture temporal and update 
-			ENQUEUE_UNIQUE_RENDER_COMMAND_FOURPARAMETER(
-				void,
-				ID3D11Texture2D*, t_texTemp, SenderStruct->texTemp,
-				ID3D11Texture2D*, t_tex, (ID3D11Texture2D*)SenderStruct->sharedResource,
-				int32, Stride, SenderStruct->w * 4,
-				FSenderStruct*, Params, SenderStruct,
+			int32 Stride = SenderStruct->w * 4;
+
+			ENQUEUE_RENDER_COMMAND(void)(
+				[SenderStruct, Stride](FRHICommandListImmediate& RHICmdList)
 				{
-					if (Params == nullptr) {
+					ID3D11Texture2D* t_texTemp = SenderStruct->texTemp;
+					ID3D11Texture2D* t_tex = (ID3D11Texture2D*)SenderStruct->sharedResource;
+
+					if (SenderStruct == nullptr) {
 						return;
 					}
 		
@@ -582,7 +576,13 @@ bool USpoutBPFunctionLibrary::SpoutReceiver(const FName spoutName, UMaterialInst
 
 
 					//Update Texture
-					RHIUpdateTexture2D(Params->Texture2DResource->GetTexture2DRHI(), 0, *Params->UpdateRegions, mapped.RowPitch, (uint8*)pixel);
+					RHIUpdateTexture2D(
+						SenderStruct->Texture2DResource->GetTexture2DRHI(),
+						0,
+						*SenderStruct->UpdateRegions,
+						mapped.RowPitch,
+						(uint8*)pixel
+					);
 
 
 				});
@@ -598,7 +598,7 @@ bool USpoutBPFunctionLibrary::SpoutReceiver(const FName spoutName, UMaterialInst
 void USpoutBPFunctionLibrary::CloseSender(FName spoutName)
 {
 
-	UE_LOG(SpoutLog, Warning, TEXT("Closing... sender %s "), *spoutName.GetPlainNameString());
+	UE_LOG(SpoutLog, Warning, TEXT("Closing... sender %s"), *spoutName.GetPlainNameString());
 
 	if (sender == nullptr)
 	{
@@ -613,7 +613,7 @@ void USpoutBPFunctionLibrary::CloseSender(FName spoutName)
 	ESpoutState state = CheckSenderState(spoutName);
 
 	if (state == ESpoutState::noEnoR) {
-		UE_LOG(SpoutLog, Warning, TEXT("already %s closed, there is nothing to close!! check the name"), *spoutName.GetPlainNameString());
+		UE_LOG(SpoutLog, Warning, TEXT("%s is already closed; there is nothing to close!! Please check the name."), *spoutName.GetPlainNameString());
 		//return;
 	}
 	if (state == ESpoutState::noER) {
@@ -622,7 +622,7 @@ void USpoutBPFunctionLibrary::CloseSender(FName spoutName)
 		//return;
 	}
 	if (state == ESpoutState::EnoR) {
-			UE_LOG(SpoutLog, Warning, TEXT("Already exist a Sender with the name %s, You can not close a sender that is not yours.??"), *spoutName.GetPlainNameString());	
+			UE_LOG(SpoutLog, Warning, TEXT("A Sender with the name %s already exists. You can not close a sender that is not yours??"), *spoutName.GetPlainNameString());	
 		//return;
 	}
 	if (state == ESpoutState::ER) {
@@ -631,14 +631,14 @@ void USpoutBPFunctionLibrary::CloseSender(FName spoutName)
 		GetSpoutRegistred(spoutName, tempSenderStruct);
 		
 		if (tempSenderStruct->spoutType == ESpoutType::Sender) {
-			UE_LOG(SpoutLog, Warning, TEXT("releasing sender %s"), *spoutName.GetPlainNameString());
+			UE_LOG(SpoutLog, Warning, TEXT("Releasing sender %s"), *spoutName.GetPlainNameString());
 			// here really release the sender
 			sender->ReleaseSenderName(TCHAR_TO_ANSI(*spoutName.ToString()));
-			UE_LOG(SpoutLog, Warning, TEXT("sender %s released"), *spoutName.GetPlainNameString());
+			UE_LOG(SpoutLog, Warning, TEXT("Sender %s released"), *spoutName.GetPlainNameString());
 			
 		}
 		else {
-			UE_LOG(SpoutLog, Warning, TEXT("receiver always listening"));
+			UE_LOG(SpoutLog, Warning, TEXT("Receiver always listening"));
 
 			FlushRenderingCommands();
 			if (tempSenderStruct->sharedResource != nullptr) {
@@ -660,7 +660,7 @@ void USpoutBPFunctionLibrary::CloseSender(FName spoutName)
 		UnregisterSpout(spoutName);
 	}
 
-	UE_LOG(SpoutLog, Warning, TEXT("There are now %i senders remaining "), FSenders.Num());
+	UE_LOG(SpoutLog, Warning, TEXT("There are now %i senders remaining"), FSenders.Num());
 	
 
 }

--- a/Source/SpoutPlugin/SpoutPlugin.Build.cs
+++ b/Source/SpoutPlugin/SpoutPlugin.Build.cs
@@ -2,89 +2,85 @@
 
 using System.IO;
 
-namespace UnrealBuildTool.ModuleRules
+namespace UnrealBuildTool.Rules
 {
     public class SpoutPlugin : ModuleRules
-{
-
-    private string ModulePath
     {
-        get { return ModuleDirectory; }
-    }
 
-    private string ThirdPartyPath
-    {
-        get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
-    }
-    
-    public SpoutPlugin(ReadOnlyTargetRules Target) : base(Target)
-    {
-        PrivatePCHHeaderFile = "Private/SpoutPluginPrivatePCH.h";
-
-        PublicIncludePaths.AddRange(
-            new string[] {
-                Path.Combine(ModulePath, "Public"),
-                Path.Combine(ThirdPartyPath, "Spout/include")
-                
-                // ... add public include paths required here ...
-            }
-            );
-        
-
-        PrivateIncludePaths.AddRange(
-            new string[] {
-                "SpoutPlugin/Private",
-                // ... add other private include paths required here ...
-            }
-            );
-
-        //AddThirdPartyPrivateStaticDependencies(Target, "Spout");
-
-        PublicDependencyModuleNames.AddRange(
-            new string[]
-            {
-                "Core",
-                "CoreUObject",
-                "Engine",
-                "RHI",
-                "RenderCore"
-                // ... add other public dependencies that you statically link with here ...
-            }
-            );
-
-        PrivateDependencyModuleNames.AddRange(
-            new string[]
-            {
-                "Slate", "SlateCore"
-                // ... add private dependencies that you statically link with here ...  
-            }
-            );
-
-
-        DynamicallyLoadedModuleNames.AddRange(
-            new string[]
-            {
-                
-                // ... add any modules that your module loads dynamically here ...
-            }
-            );
-            
-    
-
-        if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
+        private string ModulePath
         {
-            string PlatformString = (Target.Platform == UnrealTargetPlatform.Win64) ? "amd64" : "x86";
-            PublicAdditionalLibraries.Add(Path.Combine(ThirdPartyPath, "Spout/lib", PlatformString, "Spout.lib"));
+            get { return ModuleDirectory; }
+        }
 
-            RuntimeDependencies.Add(new RuntimeDependency(Path.Combine(ThirdPartyPath, "Spout/lib", PlatformString, "Spout.dll")));
-            
-            // Delay-load the DLL, so we can load it from the right place first
-            PublicDelayLoadDLLs.Add(Path.Combine(ThirdPartyPath, "Spout/lib", PlatformString, "Spout.dll"));
-            
-            
+        private string ThirdPartyPath
+        {
+            get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
         }
         
-    }
-}
+        public SpoutPlugin(ReadOnlyTargetRules Target) : base(Target)
+        {
+            PrivatePCHHeaderFile = "Private/SpoutPluginPrivatePCH.h";
 
+            PublicIncludePaths.AddRange(
+                new string[] {
+                    Path.Combine(ModulePath, "Public"),
+                    Path.Combine(ThirdPartyPath, "Spout/include")
+                    
+                    // ... add public include paths required here ...
+                }
+                );
+            
+
+            PrivateIncludePaths.AddRange(
+                new string[] {
+                    "SpoutPlugin/Private",
+                    // ... add other private include paths required here ...
+                }
+                );
+
+            //AddThirdPartyPrivateStaticDependencies(Target, "Spout");
+
+            PublicDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "Core",
+                    "CoreUObject",
+                    "Engine",
+                    "RHI",
+                    "RenderCore"
+                    // ... add other public dependencies that you statically link with here ...
+                }
+                );
+
+            PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
+                    "Slate", "SlateCore"
+                    // ... add private dependencies that you statically link with here ...  
+                }
+                );
+
+
+            DynamicallyLoadedModuleNames.AddRange(
+                new string[]
+                {
+                    
+                    // ... add any modules that your module loads dynamically here ...
+                }
+                );
+                
+        
+
+            if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
+            {
+                string PlatformString = (Target.Platform == UnrealTargetPlatform.Win64) ? "amd64" : "x86";
+                PublicAdditionalLibraries.Add(Path.Combine(ThirdPartyPath, "Spout/lib", PlatformString, "Spout.lib"));
+
+                RuntimeDependencies.Add(new RuntimeDependency(Path.Combine(ThirdPartyPath, "Spout/lib", PlatformString, "Spout.dll")));
+                
+                // Delay-load the DLL, so we can load it from the right place first
+                PublicDelayLoadDLLs.Add(Path.Combine(ThirdPartyPath, "Spout/lib", PlatformString, "Spout.dll"));
+            }
+        }
+    }
 }

--- a/Source/SpoutPlugin/SpoutPlugin.Build.cs
+++ b/Source/SpoutPlugin/SpoutPlugin.Build.cs
@@ -115,7 +115,7 @@ namespace UnrealBuildTool.Rules
 
                 string pluginDLLPath = Path.Combine(ThirdPartyPath, "Spout", "lib", PlatformString, "Spout.dll");
                 string binariesPath = CopyToProjectBinaries(pluginDLLPath, Target);
-                System.Console.WriteLine("Using Python DLL: " + binariesPath);
+                System.Console.WriteLine("Using Spout DLL: " + binariesPath);
                 RuntimeDependencies.Add(binariesPath);
             }
         }

--- a/Source/SpoutPlugin/SpoutPlugin.Build.cs
+++ b/Source/SpoutPlugin/SpoutPlugin.Build.cs
@@ -70,7 +70,7 @@ namespace UnrealBuildTool.Rules
                 );
                 
         
-
+            // This section needs work
             if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
             {
                 string PlatformString = (Target.Platform == UnrealTargetPlatform.Win64) ? "amd64" : "x86";

--- a/Source/SpoutPlugin/SpoutPlugin.Build.cs
+++ b/Source/SpoutPlugin/SpoutPlugin.Build.cs
@@ -1,10 +1,10 @@
 // Some copyright should be here...
 
-using UnrealBuildTool;
 using System.IO;
 
-
-public class SpoutPlugin : ModuleRules
+namespace UnrealBuildTool.ModuleRules
+{
+    public class SpoutPlugin : ModuleRules
 {
 
     private string ModulePath
@@ -17,58 +17,59 @@ public class SpoutPlugin : ModuleRules
         get { return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/")); }
     }
     
-	public SpoutPlugin(ReadOnlyTargetRules Target) : base(Target)
-	{
+    public SpoutPlugin(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PrivatePCHHeaderFile = "Private/SpoutPluginPrivatePCH.h";
 
         PublicIncludePaths.AddRange(
             new string[] {
-				"SpoutPlugin/Public",
+                Path.Combine(ModulePath, "Public"),
                 Path.Combine(ThirdPartyPath, "Spout/include")
-				
-				// ... add public include paths required here ...
-			}
+                
+                // ... add public include paths required here ...
+            }
             );
         
 
         PrivateIncludePaths.AddRange(
             new string[] {
-				"SpoutPlugin/Private",
-				// ... add other private include paths required here ...
-			}
+                "SpoutPlugin/Private",
+                // ... add other private include paths required here ...
+            }
             );
 
-		//AddThirdPartyPrivateStaticDependencies(Target, "Spout");
+        //AddThirdPartyPrivateStaticDependencies(Target, "Spout");
 
-		PublicDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"Core",
-				"CoreUObject",
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "CoreUObject",
                 "Engine",
                 "RHI",
                 "RenderCore"
-				// ... add other public dependencies that you statically link with here ...
-			}
-			);
+                // ... add other public dependencies that you statically link with here ...
+            }
+            );
 
         PrivateDependencyModuleNames.AddRange(
             new string[]
-			{
-				"Slate", "SlateCore"
-				// ... add private dependencies that you statically link with here ...	
-			}
+            {
+                "Slate", "SlateCore"
+                // ... add private dependencies that you statically link with here ...  
+            }
             );
 
 
         DynamicallyLoadedModuleNames.AddRange(
             new string[]
-			{
-				
-				// ... add any modules that your module loads dynamically here ...
-			}
+            {
+                
+                // ... add any modules that your module loads dynamically here ...
+            }
             );
-			
-	
+            
+    
 
         if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
         {
@@ -83,5 +84,7 @@ public class SpoutPlugin : ModuleRules
             
         }
         
-	}
+    }
+}
+
 }

--- a/SpoutPlugin.uplugin
+++ b/SpoutPlugin.uplugin
@@ -1,13 +1,14 @@
 {
 	"FileVersion": 3,
 	"FriendlyName": "Spout Plugin",
-	"Version": 2,
-	"VersionName": "1.1",
+	"Version": 3,
+	"VersionName": "1.2",
 	"CreatedBy": "ale",
 	"CreatedByURL": "",
 	"Category": "Spout",
-	"Description": "Spout Sender Receiver",
-	"EnabledByDefault": false,
+	"Description": "Enables sending and receiving of textures via Spout framework (http://spout.zeal.co/).",
+	"SupportURL": "https://L05.is",
+	"EnabledByDefault": true,
 	"Modules": [
 		{
 			"Name": "SpoutPlugin",


### PR DESCRIPTION
- Updated to work up to UE 4.23
- Fixed SpoutPlugin.Build.cs to work with 4.23, properly copy DLL files
- DLL no longer needs to be manually copied to packaged project's Binaries folder
- Updated SpoutBPFunctionLibrary.cpp to use ENQUEUE_RENDER_COMMAND
- Updated example to fix minor bugs; added comments to demonstrate different ways of using Spout Receiver

